### PR TITLE
[safdav] Update

### DIFF
--- a/safdav/src/main/java/io/github/x0b/safdav/SafAccessProvider.java
+++ b/safdav/src/main/java/io/github/x0b/safdav/SafAccessProvider.java
@@ -12,6 +12,7 @@ import io.github.x0b.safdav.file.SafConstants;
 public class SafAccessProvider {
 
     private static SafDAVServer davServer;
+    private static SafDirectServer directServer;
 
     public static SafDAVServer getServer(Context context){
         if(null == davServer){
@@ -23,6 +24,13 @@ public class SafAccessProvider {
             }
         }
         return davServer;
+    }
+
+    public static SafDirectServer getDirectServer(Context context) {
+        if(null == directServer) {
+            directServer = new SafDirectServer(context);
+        }
+        return directServer;
     }
 
 }

--- a/safdav/src/main/java/io/github/x0b/safdav/SafDirectServer.java
+++ b/safdav/src/main/java/io/github/x0b/safdav/SafDirectServer.java
@@ -1,0 +1,68 @@
+package io.github.x0b.safdav;
+
+import android.content.Context;
+import android.net.Uri;
+import io.github.x0b.safdav.saf.DocumentsContractAccess;
+import io.github.x0b.safdav.file.ItemAccess;
+import io.github.x0b.safdav.file.SafItem;
+import io.github.x0b.safdav.saf.ProviderPaths;
+
+import java.util.List;
+
+/**
+ * Access safdav methods without HTTP overhead. Useful for file operations where
+ * both source and target are SAF-accessible.
+ */
+public class SafDirectServer {
+
+    private static final String TAG = "SafDirectServer";
+    private static final String ANDROID_EXTERNAL_STORAGE_PREFIX = "content://com.android.externalstorage.documents/tree/";
+    private final Context context;
+    private final ItemAccess itemAccess;
+    private final ProviderPaths providerPaths;
+
+    SafDirectServer(Context context) {
+        this.context = context;
+        itemAccess = new DocumentsContractAccess(context);
+        providerPaths = new ProviderPaths(context);
+    }
+
+    /**
+     * Get the contents of a a directory (or a list of permissions/drives as root)
+     * @param path directory path
+     * @return a {@link List<SafItem>} of items identified by that path
+     */
+    public List<SafItem> list(String path){
+        Uri uri = providerPaths.getUriByMappedPath(path);
+        return itemAccess.list(uri);
+    }
+
+    /**
+     * Create a directory.
+     * @param path directory path
+     */
+    public void createDirectory(String path) {
+        Uri uri = providerPaths.getUriByMappedPath(path);
+        itemAccess.createDirectory(uri);
+    }
+
+    /**
+     * "Upload" or "Download" a file or directory
+     * @param srcPath item source path
+     * @param dstPath item destination path
+     */
+    public void copyItem(String srcPath, String dstPath) {
+        Uri srcUri = providerPaths.getUriByMappedPath(srcPath);
+        Uri dstUri = providerPaths.getUriByMappedPath(dstPath);
+        itemAccess.copyItem(srcUri, dstUri);
+    }
+
+    /**
+     * Delete an item
+     * @param path item path
+     */
+    public void delete(String path) {
+        Uri itemUri = providerPaths.getUriByMappedPath(path);
+        itemAccess.deleteItem(itemUri);
+    }
+}

--- a/safdav/src/main/java/io/github/x0b/safdav/provider/SingleRootProvider.java
+++ b/safdav/src/main/java/io/github/x0b/safdav/provider/SingleRootProvider.java
@@ -1,0 +1,85 @@
+package io.github.x0b.safdav.provider;
+
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.provider.DocumentsContract;
+import android.provider.DocumentsProvider;
+import androidx.annotation.AnyRes;
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public abstract class SingleRootProvider extends DocumentsProvider {
+
+    protected static final String[] DEFAULT_ROOT_PROJECTION = new String[]{
+            DocumentsContract.Root.COLUMN_ROOT_ID,
+            DocumentsContract.Root.COLUMN_ICON,
+            DocumentsContract.Root.COLUMN_TITLE,
+            DocumentsContract.Root.COLUMN_FLAGS,
+            DocumentsContract.Root.COLUMN_DOCUMENT_ID
+    };
+
+    protected static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[]{
+            DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+            DocumentsContract.Document.COLUMN_MIME_TYPE,
+            DocumentsContract.Document.COLUMN_FLAGS,
+            DocumentsContract.Document.COLUMN_SIZE,
+            DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+    };
+
+    private final String rootId;
+    private final String rootDocId;
+
+    public SingleRootProvider(String rootId, String rootDocId) {
+        this.rootId = rootId;
+        this.rootDocId = rootDocId;
+    }
+
+    protected final Cursor buildRoot(@AnyRes int icon, @StringRes int title, String summary, @RootFlags int flags) {
+        try (MatrixCursor result = new MatrixCursor(DEFAULT_ROOT_PROJECTION)) {
+            MatrixCursor.RowBuilder row = result.newRow();
+            row.add(DocumentsContract.Root.COLUMN_ROOT_ID, rootId);
+            row.add(DocumentsContract.Root.COLUMN_ICON, icon);
+            row.add(DocumentsContract.Root.COLUMN_TITLE, getContext().getString(title));
+            row.add(DocumentsContract.Root.COLUMN_FLAGS, flags);
+            row.add(DocumentsContract.Root.COLUMN_DOCUMENT_ID, rootDocId);
+            row.add(DocumentsContract.Root.COLUMN_SUMMARY, summary);
+            return result;
+        }
+    }
+
+    public final Cursor createSingleRow(@Nullable String[] columnNames, @NonNull Object... values) {
+        if(null == columnNames) {
+            columnNames = DEFAULT_DOCUMENT_PROJECTION;
+        }
+        if(columnNames.length != values.length) {
+            throw new IllegalArgumentException("Document row value length must match column name length");
+        }
+        try (MatrixCursor result = new MatrixCursor(columnNames)) {
+            result.addRow(values);
+            return result;
+        }
+    }
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @IntDef(
+            flag = true,
+            value = {DocumentsContract.Root.FLAG_LOCAL_ONLY,
+                    DocumentsContract.Root.FLAG_SUPPORTS_SEARCH,
+                    DocumentsContract.Root.FLAG_SUPPORTS_CREATE,
+                    DocumentsContract.Root.FLAG_SUPPORTS_IS_CHILD,
+                    DocumentsContract.Root.FLAG_SUPPORTS_RECENTS}
+    )
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface RootFlags {
+    }
+}

--- a/safdav/src/main/java/io/github/x0b/safdav/saf/DocumentsContractAccess.java
+++ b/safdav/src/main/java/io/github/x0b/safdav/saf/DocumentsContractAccess.java
@@ -1,0 +1,281 @@
+package io.github.x0b.safdav.saf;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.DocumentsContract;
+import android.util.Log;
+import io.github.x0b.safdav.file.FileAccessError;
+import io.github.x0b.safdav.file.ItemAccess;
+import io.github.x0b.safdav.file.ItemExistsException;
+import io.github.x0b.safdav.file.ItemNotFoundException;
+import io.github.x0b.safdav.file.SafException;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A variant of an access provider using lower level DocumentsContract and ContentResolver#query apis.
+ * Should be faster than the DocumentFile based access methods.
+ *
+ * Especially for directory lists, where all required parameters are queried at once for all files rather than letting
+ * the framework create DocumentFiles for you which will query the content resolver for _each and every_ file property
+ * on access, e.g. serialization query time == t_single-cell-query * num_files * num_properties.
+ */
+public class DocumentsContractAccess implements ItemAccess<SafFastItem> {
+
+    private static final String TAG = "DocumentsContractAccess";
+    private final Context context;
+    private final SafFileAccess sfa;
+
+    public DocumentsContractAccess(Context context) {
+        this.context = context;
+        this.sfa = new SafFileAccess(context);
+    }
+
+    @Override
+    public SafFastItem createFile(Uri uri, String name, String mimeType, InputStream content, long len) {
+        Uri parentUri = getParent(uri);
+        try {
+            Uri fileUri = DocumentsContract.createDocument(context.getContentResolver(), parentUri,
+                    mimeType, getDisplayName(uri));
+            sfa.writeFile(fileUri, content, len);
+            //return sfa.readMeta(fileUri);
+            return readMeta(uri);
+        } catch (FileNotFoundException e) {
+            throw new ItemNotFoundException(e);
+        }
+    }
+
+    @Override
+    public void createDirectory(Uri uri) {
+        try {
+            readMeta(uri);
+        } catch (ItemNotFoundException e) {
+            try {
+                DocumentsContract.createDocument(context.getContentResolver(), getParent(uri),
+                        DocumentsContract.Document.MIME_TYPE_DIR, getDisplayName(uri));
+            } catch (FileNotFoundException en) {
+                throw new ItemNotFoundException(en);
+            }
+            return;
+        }
+        throw new ItemExistsException();
+    }
+
+    @Override
+    public void deleteItem(Uri uri) {
+        try {
+            DocumentsContract.deleteDocument(context.getContentResolver(), buildHierarchicalDocumentsUri(uri));
+        } catch (FileNotFoundException e) {
+            throw new ItemNotFoundException(e);
+        }
+    }
+
+    @Override
+    public void copyItem(Uri srcUri, Uri dstUri) {
+        sfa.copyItem(srcUri, dstUri);
+    }
+
+    @Override
+    public void moveItem(Uri srcStubUri, Uri targetStubUri) {
+        Uri srcUri = buildHierarchicalDocumentsUri(srcStubUri);
+        Uri srcParentUri = getParent(srcStubUri);
+        Uri dstParentUri = getParent(targetStubUri);
+
+        if(srcParentUri.equals(dstParentUri)){
+            renameItem(srcStubUri, targetStubUri);
+            return;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            try {
+                DocumentsContract.moveDocument(context.getContentResolver(), srcUri, srcParentUri, dstParentUri);
+            } catch (FileNotFoundException e) {
+                throw new ItemNotFoundException();
+            }
+        } else {
+            sfa.moveItem(srcStubUri, targetStubUri);
+        }
+    }
+
+    @Override
+    public void renameItem(Uri item, Uri target) {
+        Uri documentUri = buildHierarchicalDocumentsUri(item);
+        try {
+            DocumentsContract.renameDocument(context.getContentResolver(), documentUri, getDisplayName(target));
+        } catch (FileNotFoundException e) {
+            throw new ItemNotFoundException();
+        }
+    }
+
+    @Override
+    public List<SafFastItem> list(Uri treeUri) {
+        ContentResolver contentResolver = context.getContentResolver();
+        Uri childDocsUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, DocumentsContract.getDocumentId(treeUri));
+        final ArrayList<SafFastItem> results = new ArrayList<>();
+
+        try (Cursor cursor = contentResolver.query(childDocsUri, new String[]{
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+                DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+                DocumentsContract.Document.COLUMN_SIZE
+        }, null, null, null)) {
+            if (null == cursor) {
+                return results;
+            }
+            while (cursor.moveToNext()) {
+                final String documentId = cursor.getString(0);
+                String mimeType = cursor.getString(2);
+                boolean isDirectory = false;
+                if (mimeType.equals(DocumentsContract.Document.MIME_TYPE_DIR)) {
+                    mimeType = "inode/directory";
+                    isDirectory = true;
+                }
+                SafFastItem item = new SafFastItem(
+                        DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId),
+                        cursor.getString(1),
+                        mimeType,
+                        cursor.getLong(3),
+                        cursor.getLong(4),
+                        isDirectory
+                );
+                results.add(item);
+            }
+        } catch (Exception e) {
+            Log.w("DocumentsContractAccess", "Failed query: " + e);
+        }
+        return results;
+    }
+
+    @Override
+    public InputStream readFile(SafFastItem documentUri) {
+        try {
+            return context.getContentResolver().openInputStream(documentUri.getUri());
+        } catch (FileNotFoundException e) {
+            throw new ItemNotFoundException(e);
+        }
+    }
+
+    @Override
+    public SafFastItem readMeta(Uri uri) {
+        ContentResolver contentResolver = context.getContentResolver();
+        Uri docUri = buildHierarchicalDocumentsUri(uri);
+        try (Cursor cursor = contentResolver.query(docUri, new String[]{
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+                DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+                DocumentsContract.Document.COLUMN_SIZE
+        }, null, null, null)) {
+            if (null == cursor) {
+                throw new ItemNotFoundException();
+            }
+            if (cursor.moveToNext()) {
+                final String documentId = cursor.getString(0);
+                String mimeType = cursor.getString(2);
+                boolean isDirectory = false;
+                List<SafFastItem> childItems = null;
+                if (mimeType.equals(DocumentsContract.Document.MIME_TYPE_DIR)) {
+                    mimeType = "inode/directory";
+                    isDirectory = true;
+                    Uri childUri = DocumentsContract.buildDocumentUriUsingTree(buildHierarchicalDocumentsUri(uri), documentId);
+                    childItems = list(childUri);
+                }
+                return new SafFastItem(
+                        DocumentsContract.buildDocumentUriUsingTree(buildHierarchicalDocumentsUri(uri), documentId),
+                        cursor.getString(1),
+                        mimeType,
+                        cursor.getLong(3),
+                        cursor.getLong(4),
+                        isDirectory,
+                        childItems
+                );
+            } else {
+                throw new ItemNotFoundException();
+            }
+        } catch (IllegalArgumentException e) {
+            throw new ItemNotFoundException(e);
+        } catch (Exception e) {
+            Log.w("DocumentsContractAccess", "Failed query: " + e);
+            throw new FileAccessError(e);
+        }
+    }
+
+    @Override
+    public void writeFile(Uri documentUri, InputStream outputStream, long len) {
+        sfa.writeFile(documentUri, outputStream, len);
+    }
+
+    private Uri getParent(Uri uri) {
+        return buildHierarchicalDocumentsUri(uri, true);
+    }
+
+    private Uri buildHierarchicalDocumentsUri(Uri uri) {
+        return buildHierarchicalDocumentsUri(uri, false);
+    }
+
+    // Note: this is modelled to observed behavior, because the
+    // DocumentsContract#fromXXUri APIs don't really work well
+    private Uri buildHierarchicalDocumentsUri(Uri uri, boolean buildParent) {
+        String path = uri.getPath();
+        int treeIndex = path.indexOf("/tree/");
+        if (0 != treeIndex) {
+            throw new SafException("Unsupported DocumentsProvider: " + uri.toString());
+        }
+        int sep;
+        if (-1 != (sep = path.indexOf(':', 6)) || -1 != (sep = path.indexOf('/', 6))) {
+            try {
+                String volume = URLEncoder.encode(path.substring(6, sep + 1), "UTF-8");
+                String pathRaw = path.substring(sep + 1);
+                String mediaPath = pathRaw.replaceAll("/", "%2F");
+
+                if (buildParent) {
+                    int parentSep = pathRaw.lastIndexOf('/');
+                    // Check: format assumption - for collections, adjust path
+                    if (parentSep == pathRaw.length() - 1) {
+                        parentSep = pathRaw.lastIndexOf('/', parentSep - 1);
+                    }
+                    // Check: is there at least one subfolder?
+                    if (parentSep != -1) {
+                        mediaPath = pathRaw.substring(0, parentSep).replaceAll("/", "%2F");
+                    } else {
+                        mediaPath = "";
+                    }
+                }
+                return Uri.parse(uri.getScheme() + "://" + uri.getAuthority() + "/tree/" + volume + "/document/" + volume + mediaPath);
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException("UTF-8 not available");
+            }
+        }
+        throw new SafException("Unsupported DocumentsProvider: " + uri.toString());
+    }
+
+    // /tree/primary:DCIM
+    // /tree/primary:DCIM/IMG_1.jpg
+    private String getDisplayName(Uri uri) {
+        List<String> segments = uri.getPathSegments();
+        String displayName;
+        String path = uri.getPath();
+        int rootSep;
+        if(segments.size() >= 3 ){
+            displayName = segments.get(segments.size()-1);
+        } else  if((rootSep = path.indexOf(':', 6)) != -1 || (rootSep = path.indexOf('/', 6)) != -1){
+            displayName = path.substring(rootSep+1);
+        } else {
+            displayName = segments.get(segments.size()-1);
+        }
+
+        if(displayName.lastIndexOf('/') == displayName.length()-1){
+            displayName = displayName.substring(0, displayName.length()-1);
+        }
+
+        return displayName;
+    }
+}

--- a/safdav/src/main/java/io/github/x0b/safdav/saf/SafFastItem.java
+++ b/safdav/src/main/java/io/github/x0b/safdav/saf/SafFastItem.java
@@ -1,0 +1,133 @@
+package io.github.x0b.safdav.saf;
+
+import android.net.Uri;
+import android.util.Log;
+import io.github.x0b.safdav.file.SafItem;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class SafFastItem implements SafItem {
+
+    // TODO: figure out if this is useful, especially for child accessing child elements vs. memory overhead
+    private final Uri uri;
+    private final String name;
+    private final String contentType;
+    private final long lastModified;
+    private final long size;
+    private final boolean isCollection;
+    private final List<? extends SafItem> items;
+
+    // TODO: figure out if thread safety is required
+    private static final SimpleDateFormat rfc1123;
+    private static final SimpleDateFormat rfc3339;
+
+    static {
+        rfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US);
+        rfc1123.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+        rfc3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault());
+        rfc3339.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    public SafFastItem(Uri uri, String name, String contentType, long lastModified, long size, boolean isCollection) {
+        this(uri, name, contentType, lastModified, size, isCollection, null);
+    }
+
+    public SafFastItem(Uri uri, String name, String contentType, long lastModified, long size, boolean isCollection, List<? extends SafItem> items) {
+        this.uri = uri;
+        this.name = name;
+        this.contentType = contentType;
+        this.lastModified = lastModified;
+        this.size = size;
+        this.isCollection = isCollection;
+        this.items = items;
+    }
+
+    @Override
+    public String getLink() {
+        if(name == null) return "";
+        String encodedName;
+        try {
+            encodedName = URLEncoder.encode(name, "UTF-8").replaceAll("\\+", "%20");
+            if(isCollection) {
+                encodedName = encodedName + '/';
+            }
+            return encodedName;
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getLastModified() {
+        return rfc1123.format(new Date(lastModified));
+    }
+
+    @Override
+    public String getCreationDate() {
+        return rfc3339.format(new Date(lastModified));
+    }
+
+    @Override
+    public String getContentLength() {
+        return Long.toString(size);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getContentType() {
+        if(isCollection) {
+            return "inode/directory";
+        } else if(null != contentType) {
+            return contentType;
+        } else {
+            return "application/octet-stream";
+        }
+    }
+
+    @Override
+    public boolean isCollection() {
+        return isCollection;
+    }
+
+    @Override
+    public String getETag() {
+        return getLastModified();
+    }
+
+    @Override
+    public String getStatus() {
+        return "HTTP/1.1 200 OK";
+    }
+
+    @Override
+    public long getLength() {
+        return size;
+    }
+
+    @Override
+    public List<? extends SafItem> getChildren() {
+        if(null != items) {
+            return items;
+        } else {
+            Log.e("SafFastItem", "Child queries not supported");
+            return new ArrayList<>();
+        }
+    }
+
+    @Override
+    public Uri getUri() {
+        return uri;
+    }
+}


### PR DESCRIPTION
Changes
 - Added direct server for non-http access
 - Added helper for SAF ContentProviders (DocumentProvider)
 - Added a new ItemAccess implementation that is both faster and uses less resources. This improves performance of most meta operations, especially directory browsing. It also uses a less memory intensive item representation.
However, this will need to be tested extensively before it can replace the default SafFileAccess.